### PR TITLE
x86_64 build needs flags -02 -fPIC

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -20,7 +20,7 @@ Installation Instructions
    cd /path/to/sboui/top/dir
    mkdir build
    cd build
-     cmake -DCMAKE_CXX_FLAGS:STRING= -2 -fPIC .. 
+     cmake -DCMAKE_CXX_FLAGS:STRING= -02 -fPIC .. 
      make
      make install
    cd ..

--- a/INSTALL
+++ b/INSTALL
@@ -15,6 +15,15 @@ Installation Instructions
      make
      make install
    cd ..
+   
+    x86_64 build   
+   cd /path/to/sboui/top/dir
+   mkdir build
+   cd build
+     cmake -DCMAKE_CXX_FLAGS:STRING= -2 -fPIC .. 
+     make
+     make install
+   cd ..
 
    This process compile the software in the /path/to/sboui/top/dir/build
    directory and install it to the default install path (root privileges may be


### PR DESCRIPTION
This is not relevant x86 but the -02  is a good thing can be used cmake may default to it.
this helps build the x86_64 